### PR TITLE
Privacy Manifest

### DIFF
--- a/MBProgressHUD.xcodeproj/project.pbxproj
+++ b/MBProgressHUD.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		D286A7531518C70F00E13FB8 /* MBProgressHUD.m in Sources */ = {isa = PBXBuildFile; fileRef = D286A7521518C70F00E13FB8 /* MBProgressHUD.m */; };
 		D286A75E1518C89600E13FB8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D286A75D1518C89600E13FB8 /* UIKit.framework */; };
 		D286A76F1518CAAD00E13FB8 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D286A76E1518CAAD00E13FB8 /* CoreGraphics.framework */; };
+		D6F68AB62B85AE7C00E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB52B85AE7400E79941 /* PrivacyInfo.xcprivacy */; };
+		D6F68AB72B85AE7D00E79941 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D6F68AB52B85AE7400E79941 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -43,6 +45,7 @@
 		D286A7521518C70F00E13FB8 /* MBProgressHUD.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBProgressHUD.m; sourceTree = SOURCE_ROOT; };
 		D286A75D1518C89600E13FB8 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		D286A76E1518CAAD00E13FB8 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		D6F68AB52B85AE7400E79941 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +82,7 @@
 				1D104D951ACA376200973364 /* Framework-Info.plist */,
 				1777D3E21D757AF50037C7F1 /* Framework-tvOS-Info.plist */,
 				1315DD73178045000032507D /* MBProgressHUD-Prefix.pch */,
+				D6F68AB52B85AE7400E79941 /* PrivacyInfo.xcprivacy */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -241,6 +245,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB72B85AE7D00E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -248,6 +253,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F68AB62B85AE7C00E79941 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
 </plist>

--- a/findRequiredReasonAPIUsage.sh
+++ b/findRequiredReasonAPIUsage.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Created with reference below
+# https://gist.github.com/MarcoEidinger/22feb1588c3d7be41c42853a77e52772
+
+# https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+searchTerms=(
+    # Swift
+    ## File timestamp APIs
+    "creationDate"
+    "modificationDate"
+    "fileModificationDate"
+    "contentModificationDateKey"
+    "creationDateKey"
+    "getattrlist"
+    "getattrlistbulk"
+    "fgetattrlist"
+    "stat"
+    "fstat"
+    "fstatat"
+    "lstat"
+    "getattrlistat"
+    ## System boot time APIs
+    "systemUptime"
+    "mach_absolute_time"
+    ## Disk space APIs
+    "volumeAvailableCapacityKey"
+    "volumeAvailableCapacityForImportantUsageKey"
+    "volumeAvailableCapacityForOpportunisticUsageKey"
+    "volumeTotalCapacityKey"
+    "systemFreeSize"
+    "systemSize"
+    "statfs"
+    "statvfs"
+    "fstatfs"
+    "fstatvfs"
+    "getattrlist"
+    "fgetattrlist"
+    "getattrlistat"
+    ## Active keyboard APIs
+    "activeInputModes"
+    ## User defaults APIs
+    "UserDefaults"
+    # Objc
+    ## File timestamp APIs
+    NSFileCreationDate
+    NSFileModificationDate
+    fileModificationDate
+    NSURLContentModificationDateKey
+    NSURLCreationDateKey
+    getattrlist
+    getattrlistbulk
+    fgetattrlist
+    stat
+    fstat
+    fstatat
+    lstat
+    getattrlistat
+    ## System boot time APIs
+    systemUptime
+    mach_absolute_time
+    ## Disk space APIs
+    NSURLVolumeAvailableCapacityKey
+    NSURLVolumeAvailableCapacityForImportantUsageKey
+    NSURLVolumeAvailableCapacityForOpportunisticUsageKey
+    NSURLVolumeTotalCapacityKey
+    NSFileSystemFreeSize
+    NSFileSystemSize
+    statfs
+    statvfs
+    fstatfs
+    fstatvfs
+    getattrlist
+    fgetattrlist
+    getattrlistat
+    ## Active keyboard APIs
+    activeInputModes
+    ## User defaults APIs
+    NSUserDefaults
+)
+search_dir="$1"
+
+if [ -z "$search_dir" ]; then
+    echo "Usage: $0 <search_dir>"
+    exit 1
+fi
+
+for pattern in "${searchTerms[@]}"; do
+    results=`find "$search_dir" -type f \( -name "*.swift" -o -name "*.m" \) -exec grep -Hn -Fw "$pattern" {} + | awk -F ':' -v OFS='\t' '{ print $1,$2,$3 }'`
+    while read line
+    do
+    echo "${pattern}\t${line}"
+    done <<< "${results}"
+done


### PR DESCRIPTION
## 修正内容

Privacy Manifest対応として `PrivacyInfo.xcprivacy` を追加。

Appleが公開している[PrivacyManifest対応を要するSDKのリスト](https://developer.apple.com/jp/support/third-party-SDK-requirements/)にMBProgressHUDは記載されているが、[Required reason APIのリスト](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc)に記載されているAPIはコンパイルされるコード上には存在しない。

### API探索スクリプト（findRequiredReasonAPIUsage.sh）実行結果

```
JP-NVFP09JFQQ:MBProgressHUD yukihiro.sato$ sh findRequiredReasonAPIUsage.sh .
creationDate
modificationDate
fileModificationDate
contentModificationDateKey
creationDateKey
getattrlist
getattrlistbulk
fgetattrlist
stat
fstat
fstatat
lstat
getattrlistat
systemUptime
mach_absolute_time
volumeAvailableCapacityKey
volumeAvailableCapacityForImportantUsageKey
volumeAvailableCapacityForOpportunisticUsageKey
volumeTotalCapacityKey
systemFreeSize
systemSize
statfs
statvfs
fstatfs
fstatvfs
getattrlist
fgetattrlist
getattrlistat
activeInputModes
UserDefaults
NSFileCreationDate
NSFileModificationDate
fileModificationDate
NSURLContentModificationDateKey
NSURLCreationDateKey
getattrlist
getattrlistbulk
fgetattrlist
stat
fstat
fstatat
lstat
getattrlistat
systemUptime
mach_absolute_time
NSURLVolumeAvailableCapacityKey
NSURLVolumeAvailableCapacityForImportantUsageKey
NSURLVolumeAvailableCapacityForOpportunisticUsageKey
NSURLVolumeTotalCapacityKey
NSFileSystemFreeSize
NSFileSystemSize
statfs
statvfs
fstatfs
fstatvfs
getattrlist
fgetattrlist
getattrlistat
activeInputModes
NSUserDefaults
```

ということなのでほぼファイルを追加したのみになっている（何のために必要なのか...）。

## 動作確認

- [x] ビルドできること
